### PR TITLE
Now returns correct aggregated markets list when calling "getmarkets"

### DIFF
--- a/cryptsy.js
+++ b/cryptsy.js
@@ -139,7 +139,7 @@ function CryptsyClient(key, secret) {
 
         self.markets[primary + secondary] = markets[i].marketid;
       }
-      callback(error, markets);
+      callback(error, self.markets);
     }
     api_query('getmarkets', callback2);
   }


### PR DESCRIPTION
self.getmarkets invokes callback with "markets" parameter which is - in current Cryptsy API - an array (not a dictionnary). I think you would return the "self.market" instead, because it is the generated dictionnary with currencies_pair as keys.
