### PR TITLE
Checks for self.markets keys before requesting market ids

### DIFF
--- a/cryptsy.js
+++ b/cryptsy.js
@@ -93,7 +93,7 @@ function CryptsyClient(key, secret) {
       throw new Error("'callback' argument must be a function.");
     }
 
-    if(!self.markets || !self.markets.length) {
+    if(!self.markets || !Object.keys(self.markets).length) {
       self.getmarkets(function(error, markets) {
         callback.call(this, error, markets[marketname]);
       });


### PR DESCRIPTION
The clause "!self.markets.length" is the condition used for market ids lazy loading didn't work because self.markets is an Object (not an array). Now counting Object keys before sending a new request to the server. This is not a robust fix, but it will work if "self.markets" is used only for storing market ids mapping.
