### PR TITLE
Fix undefined data callback when creating orders

### DIFF
--- a/cryptsy.js
+++ b/cryptsy.js
@@ -84,6 +84,8 @@ function CryptsyClient(key, secret) {
           // The return parameter is not available when we create an order
           if (response.return) {
             callback.call(this, null, response.return);
+            
+            return;
           }
           callback.call(this, null, response);
         }

--- a/cryptsy.js
+++ b/cryptsy.js
@@ -81,7 +81,11 @@ function CryptsyClient(key, secret) {
           callback.call(this, error, null);
         }
         else {
-          callback.call(this, null, response.return);
+          // The return parameter is not available when we create an order
+          if (response.return) {
+            callback.call(this, null, response.return);
+          }
+          callback.call(this, null, response);
         }
       }
     });


### PR DESCRIPTION
When we use 'createorder', the callback data remain undefined, because the response does not contain 'return' parameter in the json object.
