### PR TITLE
"error in server response" case leads to multiple cb calls

### DIFF
--- a/cryptsy.js
+++ b/cryptsy.js
@@ -63,10 +63,6 @@ function CryptsyClient(key, secret) {
 
       if(!body || !res || res.statusCode != 200) {
         error = "Error in server response.";
-
-        setTimeout(function() {
-          api_query(method, callback, args);
-        }, 500);
       }
       else {
         var response = JSON.parse(body);


### PR DESCRIPTION
either the setTimeout api_call redo gets removed or the callback.call part needs to be moved up into the else part. The way its currently handled in the "error in server response" redoes the api call which will execute the callback method and its called anyway later.
